### PR TITLE
Update about.md to direct users to the new URL

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -6,9 +6,15 @@ lede: "Epistol&#xe6 is a collection of letters to and from women in the Middle A
 
 <div class="row">
 <div class="col-md-7">
-<p>Epistol&#xe6 is a collection of letters to and from women in the Middle Ages, from the 4th to the 13th century. The letters, written in Latin, are linked to the names of the women involved, with English translations and, where available, biographical sketches of the women and some description of the subject matter or the historic context of the letter.</p>
-<p>The letters were originally collected and translated by Professor Joan Ferrante of Columbia University, mainly from printed sources. The <a href="https://ctl.columbia.edu">Columbia Center for Teaching and Learning</a> (formerly the Columbia Center for New Media Teaching and Learning) has collaborated with Professor Ferrante to develop a free, online repository of the collection.</p>
-<p>In 2022, Epistol&#xe6 was preserved as a static project and is now published by Columbia University Libraries. In addition to this site, archived and downloadable versions of the biographies and letters may be accessed through the Libraries' <a href="https://academiccommons.columbia.edu/detail/epistolae">Academic Commons</a> repository. </p>
+  Epistolæ 
+
+<h2>About the website</h2>
+<p>This site in its entirety has been moved to the University of Siena, where it will remain an ongoing project under the direction of Professors Francesco Stella and Elisabetta Bartoli. The new site is available at <a href="https://epistolae.unisi.it">https://epistolae.unisi.it</a>.</p>
+<p>This site was originally developed at the <a href="https://ctl.columbia.edu">Columbia Center for Teaching and Learning</a> (formerly the Columbia Center for New Media Teaching and Learning) and has been <a href="http://wayback.archive-it.org.ezproxy.cul.columbia.edu/1914/epistolae.ctl.columbia.edu">archived by the Columbia University libraries</a> where it remains available. In addition to the archived site, archived and downloadable versions of the biographies and letters may be accessed through the Libraries' <a href="https://academiccommons.columbia.edu/detail/epistolae">Academic Commons</a> repository.</p>
+
+<h2>About the project</h2>
+<p>The original version of Epistol&#xe6 is a collection of medieval Latin letters to and from women, dating from the 4th to the 13th centuries. Presented in their original Latin as well as in English translation, the letters are organized by the name and biography of the women writers or recipients. Biographical sketches of the women, descriptions of the subject matter of the letters, and the historical context of the correspondence are included where available. The letters were collected by Professor Joan Ferrante of Columbia University and her colleagues, mainly though not entirely from printed sources.</p>
+<p>The letters were originally collected and translated by Professor Joan Ferrante of Columbia University, mainly from printed sources. The has collaborated with Professor Ferrante to develop a free, online repository of the collection.</p>
 <p>A few notes for readers not familiar with medieval letters: it was common practice for those women and men who engaged in correspondence to dictate their letters to secretaries who not only copied them but sometimes edited them before sending them, and letters were copied and collected by recipients as well as by senders. One can not, therefore, assume that the words are precisely those of the sender, but in general, unless an intentional deception was involved, they represent the views or intentions of the senders.</p>
 <p>Names can be spelled in various ways; we attempt to give the most common variations.</p>
 <p>Biblical references may not correspond to the text the reader is familiar with. Usually they refer to the Vulgate, but some writers cite other versions, other writers give an approximation as if it were an exact quotation.</p>
@@ -24,20 +30,20 @@ For information about Epistol&#xe6, or to offer feedback, please contact us at <
 <div class="col">
 <h3 class="mt-0">What is Epistol&#xe6?</h3>
 <div class="embed-responsive embed-responsive-16by9">
-    <iframe title="What is Epistolae" class="embed-responsive-item" src="https://www.youtube.com/embed/0-Ml0RQ4nR0?wmode=opaque&amp;controls=&amp;modestbranding=1" frameborder="0" allowfullscreen="">
-    </iframe>
+  <iframe title="What is Epistolae" class="embed-responsive-item" src="https://www.youtube.com/embed/0-Ml0RQ4nR0?wmode=opaque&amp;controls=&amp;modestbranding=1" frameborder="0" allowfullscreen="">
+  </iframe>
 </div>
 
 <h3 class="mt-5">Meet Prof. Joan Ferrante</h3>
 <div class="embed-responsive embed-responsive-16by9">
-    <iframe title="Meet Professor Joan Ferrante" class="embed-responsive-item" src="https://www.youtube.com/embed/0FFnvUPQQD0?wmode=opaque&amp;controls=&amp;modestbranding=1" frameborder="0" allowfullscreen="">
-    </iframe>
+  <iframe title="Meet Professor Joan Ferrante" class="embed-responsive-item" src="https://www.youtube.com/embed/0FFnvUPQQD0?wmode=opaque&amp;controls=&amp;modestbranding=1" frameborder="0" allowfullscreen="">
+  </iframe>
 </div>
 
 <h3 class="mt-5">Research Resource</h3>
 <div class="embed-responsive embed-responsive-16by9">
-    <iframe title="Research resource" class="embed-responsive-item" src="https://www.youtube.com/embed/ZM-ZMpeH35Q?wmode=opaque&amp;controls=&amp;modestbranding=1" frameborder="0" allowfullscreen="">
-    </iframe>
+  <iframe title="Research resource" class="embed-responsive-item" src="https://www.youtube.com/embed/ZM-ZMpeH35Q?wmode=opaque&amp;controls=&amp;modestbranding=1" frameborder="0" allowfullscreen="">
+  </iframe>
 </div>
 
 </div>


### PR DESCRIPTION
The University of Sienna will host the Epistolae project moving forward. This update will be provided on https://epistolae.ctl.columbia.edu/ for 12 months so that users can update their bookmarks